### PR TITLE
Fixed Added return type void to DiscordHandler::write()

### DIFF
--- a/src/DiscordHandler.php
+++ b/src/DiscordHandler.php
@@ -43,7 +43,7 @@ class DiscordHandler extends AbstractProcessingHandler
      * @param array $record
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $formatter = new LineFormatter(null, null, true, true);
         $formatter->includeStacktraces();


### PR DESCRIPTION
Added return type void to match Monolog\Handler\AbstractProcessingHandler::write() and fix the following error:

`Declaration of KABBOUCHI\LoggerDiscordChannel\DiscordHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void`